### PR TITLE
#46 Update to Foundry VTT 14

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,11 +21,11 @@
     ],
     "socket": true,
     "minimumCoreVersion": "9.0",
-    "compatibleCoreVersion": "13",
+    "compatibleCoreVersion": "14",
     "compatibility": {
         "minimum": "9",
-        "verified": "13",
-        "maximum" : "13"
+        "verified": "14",
+        "maximum" : "14"
     },
     "languages": [
         {

--- a/src/settings.js
+++ b/src/settings.js
@@ -207,7 +207,7 @@ export class helpMenu extends FormApplication {
                 "Shared Vision: " +
                 game.i18n.localize("SharedVision.Sett.Help"),
             template: "./modules/SharedVision/templates/helpMenu.html",
-            width: "500px",
+            width: 500,
         });
     }
 
@@ -264,7 +264,7 @@ export class configMenu extends FormApplication {
                 "Shared Vision: " +
                 game.i18n.localize("SharedVision.Conf.Title"),
             template: "./modules/SharedVision/templates/config.html",
-            width: "500px",
+            width: 500,
         });
     }
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -78,20 +78,12 @@
             <td>{{c.name}}</td>
             <td class="sharedVision_table_select">
                 <select name="combatSelect-start-{{c.id}}">
-                    {{#select c.start}}
-                    <option value="none">No Change</option>
-                    <option value="enable">Enable</option>
-                    <option value="disable">Disable</option>
-                    {{/select}}
+                    {{selectOptions (object none="No Change" enable="Enable" disable="Disable") selected=c.start}}
                 </select>
             </td>
             <td class="sharedVision_table_select">
                 <select name="combatSelect-end-{{c.id}}">
-                    {{#select c.end}}
-                    <option value="none">No Change</option>
-                    <option value="enable">Enable</option>
-                    <option value="disable">Disable</option>
-                    {{/select}}
+                    {{selectOptions (object none="No Change" enable="Enable" disable="Disable") selected=c.end}}
                 </select>
             </td>
         </tr>


### PR DESCRIPTION
Hey!

Was looking at this module for usage within v14 and ran into a small issue with the configuration menu within the settings pane. 

Ended up being a pair of small issues, the "width" param is expecting a number, so once it gets processed into CSS it ends up being `NaNpx`. The other issue is due to a change in the handlebar template generation. the #select has been replaced with selectOptions: https://foundryvtt.com/api/functions/foundry.applications.handlebars.selectOptions.html 

This restores functionality that was there in 12, but still unfortunately retains the known issue where you have to interact with the canvas for the settings to load to players. (#40) 