### PR TITLE
#40: Initialize token vision sources with canvas perception

### DIFF
--- a/src/misc.js
+++ b/src/misc.js
@@ -86,7 +86,11 @@ export async function disableAll(en) {
 }
 
 export async function initializeSources(updateSource = false) {
-    canvas.perception.initialize({
+  for (const token of canvas.tokens.placeables) {
+      token.initializeVisionSource?.();
+  }
+
+  canvas.perception.initialize({
         sight: { initialize: true, refresh: true },
         lighting: { refresh: true },
         sounds: { refresh: true },


### PR DESCRIPTION
When the scene loads (or new tokens are added), tokens may not have their VisionSource object built by foundry. When you interact with the canvas, it will then initialize that VisionSource elsewhere in the engine. 

We can force the token to initialize the VisionSource object, allowing the canvas.perception.initialize to work correctly. 

The vision is now able to be enabled/disabled at will, and will update properly with the updates to settings / tokens / scene loads. 

https://foundryvtt.com/api/classes/foundry.canvas.placeables.Token.html#initializevisionsource 


Note, this will make the initializeSources() function heavier, but it is not called super frequently, so likely worth the extra processing. 


